### PR TITLE
Update expectations about FedoraResource::getPath

### DIFF
--- a/src/main/java/org/fcrepo/transform/transformations/LDPathTransform.java
+++ b/src/main/java/org/fcrepo/transform/transformations/LDPathTransform.java
@@ -114,7 +114,7 @@ public class LDPathTransform implements Transformation<List<Map<String, Collecti
         };
 
         final List<String> rdfStringTypes = rdfTypes.stream().map(namespaceUriToPrefix)
-                .map(stringType -> transformResource.getPath() + "/" + stringType + "/jcr:content")
+                .map(stringType -> transformResource.getPath() + "/" + stringType)
                 .collect(Collectors.toList());
 
         final FedoraBinary transform = (FedoraBinary) transformResource.getChildren()

--- a/src/test/java/org/fcrepo/transform/transformations/LDPathTransformTest.java
+++ b/src/test/java/org/fcrepo/transform/transformations/LDPathTransformTest.java
@@ -138,7 +138,7 @@ public class LDPathTransformTest {
         when(mockConfigNode.getPath()).thenReturn(CONFIGURATION_FOLDER + "some-program");
         final FedoraBinary mockChildConfig = mock(FedoraBinary.class);
         when(mockChildConfig.getPath())
-                .thenReturn(CONFIGURATION_FOLDER + "some-program/" + customNsPrefix + ":type/jcr:content");
+                .thenReturn(CONFIGURATION_FOLDER + "some-program/" + customNsPrefix + ":type");
         when(mockConfigNode.getChildren()).thenReturn(Stream.of(mockChildConfig));
 
         final URI mockRdfType = UriBuilder.fromUri(customNsUri + "type").build();


### PR DESCRIPTION
getPath() no longer includes a trailing "/jcr:content" string

Follow-on to: https://jira.duraspace.org/browse/FCREPO-1694
